### PR TITLE
Hacked up python to get AllowUntrustedUsers working

### DIFF
--- a/okta_openvpn.py
+++ b/okta_openvpn.py
@@ -241,6 +241,7 @@ class OktaOpenVPNValidator:
         self.okta_config = {}
         self.username_suffix = None
         self.always_trust_username = False
+        self.username_as_common_name = False
 
     def read_configuration_file(self):
         cfg_path_defaults = [
@@ -250,6 +251,7 @@ class OktaOpenVPNValidator:
         cfg_path = cfg_path_defaults
         parser_defaults = {
             'AllowUntrustedUsers': self.always_trust_username,
+            'UsernameAsCommonName': self.username_as_common_name,
             'UsernameSuffix': self.username_suffix,
             }
         if self.config_file:
@@ -267,7 +269,8 @@ class OktaOpenVPNValidator:
                         }
                     always_trust_username = cfg.get(
                         'OktaAPI',
-                        'AllowUntrustedUsers')
+                        'AllowUntrustedUsers',
+                        'UsernameAsCommonName')
                     if always_trust_username == 'True':
                         self.always_trust_username = True
                     self.username_suffix = cfg.get('OktaAPI', 'UsernameSuffix')
@@ -287,7 +290,11 @@ class OktaOpenVPNValidator:
             log.critical('OKTA_TOKEN not defined in configuration')
             return False
         # Taken from a validated VPN client-side SSL certificate
-        username = self.env.get('username')
+        if self.username_as_common_name:
+          username = self.env.get('username')
+        else
+          username = self.env.get('common_name')
+
         password = self.env.get('password')
         client_ipaddr = self.env.get('untrusted_ip', '0.0.0.0')
         # Note:

--- a/okta_openvpn.py
+++ b/okta_openvpn.py
@@ -267,12 +267,19 @@ class OktaOpenVPNValidator:
                         'okta_url': cfg.get('OktaAPI', 'Url'),
                         'okta_token': cfg.get('OktaAPI', 'Token'),
                         }
+
                     always_trust_username = cfg.get(
                         'OktaAPI',
-                        'AllowUntrustedUsers',
-                        'UsernameAsCommonName')
+                        'AllowUntrustedUsers')
                     if always_trust_username == 'True':
                         self.always_trust_username = True
+
+                    username_as_common_name = cfg.get(
+                        'OktaAPI',
+                        'UsernameAsCommonName')
+                    if username_as_common_name == 'True':
+                        self.username_as_common_name = True
+
                     self.username_suffix = cfg.get('OktaAPI', 'UsernameSuffix')
                     return True
                 except MissingSectionHeaderError, e:

--- a/okta_openvpn.py
+++ b/okta_openvpn.py
@@ -292,7 +292,7 @@ class OktaOpenVPNValidator:
         # Taken from a validated VPN client-side SSL certificate
         if self.username_as_common_name:
           username = self.env.get('username')
-        else
+        else:
           username = self.env.get('common_name')
 
         password = self.env.get('password')

--- a/okta_openvpn.py
+++ b/okta_openvpn.py
@@ -47,9 +47,9 @@ log.addHandler(syslog)
 # errlog.setFormatter(logging.Formatter(syslog_fmt))
 # log.addHandler(errlog)
 # # Uncomment to enable logging to a file
-# filelog = logging.FileHandler('/tmp/okta_openvpn.log')
-# filelog.setFormatter(logging.Formatter(syslog_fmt))
-# log.addHandler(filelog)
+filelog = logging.FileHandler('/var/log/okta_openvpn.log')
+filelog.setFormatter(logging.Formatter(syslog_fmt))
+log.addHandler(filelog)
 
 
 class PinError(Exception):
@@ -232,7 +232,7 @@ class OktaAPIAuth:
 class OktaOpenVPNValidator:
     def __init__(self):
         self.cls = OktaAPIAuth
-        self.username_trusted = False
+        self.username_trusted = True
         self.user_valid = False
         self.control_file = None
         self.site_config = {}
@@ -287,7 +287,7 @@ class OktaOpenVPNValidator:
             log.critical('OKTA_TOKEN not defined in configuration')
             return False
         # Taken from a validated VPN client-side SSL certificate
-        username = self.env.get('common_name')
+        username = self.env.get('username')
         password = self.env.get('password')
         client_ipaddr = self.env.get('untrusted_ip', '0.0.0.0')
         # Note:


### PR DESCRIPTION
Setting AllowUntrustedUsers: True appears to not function as expected.  I hacked up the python to force it to always read from the username.
